### PR TITLE
Update bower.json to use correct 'main' file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "angular-gaugejs",
   "version": "0.1",
   "main": [
-    "angular-gaugejs.js"
+    "src/angular-gauge.js"
   ],
   "ignore": [
     "README.md"


### PR DESCRIPTION
When injecting files using main-bower-files or anything else that gets its sources from bower.json, it fails because